### PR TITLE
Implementación para remover certamenes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 
 # C/C++ Binaries
 bin/insert_cert
+bin/remove_cert
 
 # Distribution / packaging
 .Python

--- a/bin/src/remove_cert.cpp
+++ b/bin/src/remove_cert.cpp
@@ -1,0 +1,62 @@
+#include <bits/stdc++.h>
+#include <regex>
+using namespace std;
+
+const regex regex_("  \"[a-zA-z0-9]+\": \\{");
+
+void replaceData(string &line, string type, string name, string date) {
+    map<string, string> data = {
+        {"&", string(1,34)},
+        {"[TYPE]", type},
+        {"[NAME]", name},
+        {"[DATE]", date},
+    };
+    for(auto &k: data){
+        int pos = line.find(k.first);
+        while(pos != string::npos){
+            string aux_line = line.substr(pos + k.first.size());
+            line.replace(line.begin() + pos, line.end(), k.second);
+            line += aux_line;
+            pos = line.find(k.first);
+        }
+    }
+}
+void removeByDate(vector<string> &file_lines, string parent, string type, string name, string date){
+    string line_to_delete = "      { &type&: &[TYPE]&, &name&: &[NAME]&, &date&: &[DATE]& }";
+    replaceData(line_to_delete, type, name, date);
+    bool found_parent = false;
+    for(auto &l : file_lines){
+        if(regex_match(l, regex_)){
+            string parent_line = l.substr(l.find("\"") + 1, l.find("\"", l.find("\"") + 1) - l.find("\"") - 1);
+            found_parent = !parent.compare(parent_line);
+        }
+        if(!l.compare(line_to_delete) && found_parent) {
+            if((*(&l-1)).find("[") == string::npos) {
+                (*(&l-1)) = (*(&l-1)).substr(0, (*(&l-1)).size() - 1);
+            } // fix trailing comma
+        }
+        if((!l.compare(line_to_delete) || !l.compare(line_to_delete + ",")) && found_parent) {
+            file_lines.erase(find(file_lines.begin(), file_lines.end(), l));
+        }
+    }
+}
+int main(int argc, char *argv[]) { // ./remove_cert gen2022 Cert Calculo III 2020-09-03
+    vector<string> args(argv, argv+argc);
+    const string file_location = "data/certs.json", parent = args[1];
+    string name = "";
+	for (unsigned i=3; i < args.size()- 1; ++i) name += args[i] + (i + 1 == args.size()- 1 ? "" : " ");
+    fstream file(file_location, ios::in);
+    vector<string> file_lines;
+    if(file.is_open()) {
+        string file_line;
+        while(getline(file, file_line)) file_lines.push_back(file_line);
+        file.close();
+        removeByDate(file_lines, parent, args[2], name, args[args.size() - 1]);
+        fstream file(file_location, ios::out);
+        for(auto &l : file_lines) file << l << endl;
+        file.close();
+	} else {
+		cout << "An error has occured while opening the file :/\n";
+	}
+    return 0;
+}

--- a/components/fetch.py
+++ b/components/fetch.py
@@ -31,4 +31,9 @@ def get_certs_data():
         data = json.load(file)
     return data
 
+def getExams(chat_id, subject):
+    generation = get_generation(chat_id)
+    data = get_certs_data()[generation]['certs']
+    exams = [(e['type'], e['date']) for e in data if e['name'] == subject]
+    return None if not exams else exams
 # Develop fetch quotes for get() 

--- a/components/modify_data.py
+++ b/components/modify_data.py
@@ -33,6 +33,27 @@ def args_are_ok(args, command):
         return True
 
     if command == "del_cert":
+        try:
+            if args[0] in ["Cert", "Test"]:
+                try:
+                    date = args[-1].split("-")
+                except:
+                    return False
+                if len(date) != 3:
+                    return False
+                if len(date[0]) != 4:
+                    return False
+                try :
+                    y = int(date[0]) # Year
+                    m = int(date[1]) # Month
+                    d = int(date[2]) # Day
+                except:
+                    return False 
+
+                if d > 31 or m > 12:
+                    return False
+        except:
+            return False
         return True
 
 def add_cert(args, usr_id, chat_id, gen):
@@ -49,4 +70,49 @@ def add_cert(args, usr_id, chat_id, gen):
         exit(1)
 
 def del_cert(args, usr_id, chat_id, gen):
-    pass
+    cmd = "bin/remove_cert "
+    
+    if args[0] in ["Cert", "Test"]:
+        cmd += f"{gen} {args[0]}"
+        for i in range(1, len(args)):
+            cmd += " " + args[i]
+        try:
+            os.system(cmd)
+            return "🎉 ¡Evaluación removida!"
+        except:
+            print("An error has occured while modifying the data :/")
+            exit(1)
+    name = ""
+    for i in range(0, len(args) - 1):
+        name += args[i]
+        if(i != len(args) - 2):
+            name += " "
+    exams = getExams(chat_id, name)
+    if exams is None:
+        name = ""
+        for i in range(0, len(args)):
+            name += args[i]
+            if(i != len(args) - 1):
+                name += " "
+        exams = getExams(chat_id, name)        
+    try:
+        number = int(args[-1])
+        if exams is None:
+            return "❌ ¡No se encontró el ramo!"
+        if number > len(exams) or number < 0:
+            return "❌ ¡No se encontró la evaluación!"
+        cmd = f"bin/remove_cert {gen} {exams[number - 1][0]} {name} {exams[number - 1][1]}"
+        try:
+            os.system(cmd)
+            return "🎉 ¡Evaluación removida!"
+        except:
+            print("An error has occured while modifying the data :/")
+            exit(1)
+    except:
+        if exams is None:
+            return "❌ ¡No se encontró el ramo!"
+        body = f" Evaluaciones de **{name}** \n"
+        for i in range(len(exams)):
+            body += f" • {i + 1} | {exams[i][0]} - {exams[i][1]}\n"
+        body += f" Utiliza \"/sched del {name} <ID>\" para\neliminar alguna evaluación."
+        return body

--- a/data/certs.json
+++ b/data/certs.json
@@ -27,7 +27,7 @@
       { "type": "Cert", "name": "Álgebra II", "date": "2022-07-09" },
 
       { "type": "Cert", "name": "Programación I", "date": "2022-07-11" },
-      { "type": "Cert", "name": "Programación I", "date": "2022-05-02" },
+      { "type": "Cert", "name": "Programación I", "date": "2022-05-02" }
     ]
   },
   "testing": {

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ dt = datetime.now(tz)
 if not os.path.exists('bin/insert_cert'):
     command = "g++ bin/src/insert_cert.cpp -o bin/insert_cert"
     subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-if not os.path.exists('bin/insert_cert'):
+if not os.path.exists('bin/remove_cert'):
     command = "g++ bin/src/remove_cert.cpp -o bin/remove_cert"
     subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 

--- a/main.py
+++ b/main.py
@@ -35,7 +35,9 @@ dt = datetime.now(tz)
 if not os.path.exists('bin/insert_cert'):
     command = "g++ bin/src/insert_cert.cpp -o bin/insert_cert"
     subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
+if not os.path.exists('bin/insert_cert'):
+    command = "g++ bin/src/remove_cert.cpp -o bin/remove_cert"
+    subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 def main():
     dp = updater.dispatcher


### PR DESCRIPTION
Hola!.
 Una pequeña implementación para remover los certamenes/test, probablemente la implementación de los métodos en  `components/modify_data.py` se pueden mejorar. Estos se pueden eliminar siguiendo el formato que se tiene para agregarlos además de eliminarlos dada una "ID" obtenidas utilizando "/sched del [ramo]", para luego "/sched del [ramo] [ID]". La ID no es única solamente es de acorde a los elementos almacenados.

Por otra parte se eliminó una _tailing comma_, de `data/certs.json`, alguos fetchs daban error por esta coma.

Saludos!
